### PR TITLE
Templatehaskell

### DIFF
--- a/C-structs.cabal
+++ b/C-structs.cabal
@@ -46,6 +46,7 @@ Test-Suite unit-tests
     Other-Extensions:
         ForeignFunctionInterface
         TemplateHaskell
+        CPP
     Other-Modules:
         UnitTests,
         Properties,

--- a/C-structs.cabal
+++ b/C-structs.cabal
@@ -33,11 +33,10 @@ Library
         Foreign.C.Structs.Utils
     Other-Extensions:
         TemplateHaskell
-    GHC-Options: -dth-dec-file
     Default-Language: Haskell2010
     Build-Depends:
         base >= 3.0.0 && < 5.0.0,
-        template-haskell >= 2.2 && < 2.16
+        template-haskell >= 2.2 && < 2.17
     HS-Source-Dirs: src
 
 Test-Suite unit-tests
@@ -61,7 +60,7 @@ Test-Suite unit-tests
         base         >= 3.0 && < 5.0,
         HUnit        >= 1.2 && < 1.7,
         QuickCheck   >= 2.3 && < 2.15,
-        template-haskell >= 2.2 && < 2.16,
+        template-haskell >= 2.2 && < 2.17,
         test-framework  >= 0.4.1 && < 0.9,
         test-framework-th >= 0.1.2 && < 0.3,
         test-framework-hunit >= 0.2.6 && < 0.4,

--- a/C-structs.cabal
+++ b/C-structs.cabal
@@ -33,6 +33,7 @@ Library
         Foreign.C.Structs.Utils
     Other-Extensions:
         TemplateHaskell
+        CPP
     Default-Language: Haskell2010
     Build-Depends:
         base >= 3.0.0 && < 5.0.0,

--- a/C-structs.cabal
+++ b/C-structs.cabal
@@ -51,7 +51,7 @@ Test-Suite unit-tests
         UnitTests,
         Properties,
         CTest,
-        CTestTemplate
+        Templates
     Default-Language: Haskell2010
     hs-source-dirs: test
     include-dirs: test/libs

--- a/C-structs.cabal
+++ b/C-structs.cabal
@@ -37,10 +37,14 @@ Library
 Test-Suite unit-tests
     type: exitcode-stdio-1.0
     main-is: Main.hs
+    Other-Extensions:
+        ForeignFunctionInterface
+        TemplateHaskell
     Other-Modules:
         UnitTests,
         Properties,
-        CTest
+        CTest,
+        CTestTemplate
     Default-Language: Haskell2010
     hs-source-dirs: test
     include-dirs: test/libs
@@ -51,7 +55,9 @@ Test-Suite unit-tests
         base         >= 3.0 && < 5.0,
         HUnit        >= 1.2 && < 1.7,
         QuickCheck   >= 2.3 && < 2.15,
+        template-haskell >= 2.2 && < 2.16,
         test-framework  >= 0.4.1 && < 0.9,
+        test-framework-th >= 0.1.2 && < 0.3,
         test-framework-hunit >= 0.2.6 && < 0.4,
         test-framework-quickcheck2 >= 0.2.8 && < 0.4
 

--- a/C-structs.cabal
+++ b/C-structs.cabal
@@ -64,7 +64,6 @@ Test-Suite unit-tests
         QuickCheck   >= 2.3 && < 2.15,
         template-haskell >= 2.2 && < 2.17,
         test-framework  >= 0.4.1 && < 0.9,
-        test-framework-th >= 0.1.2 && < 0.3,
         test-framework-hunit >= 0.2.6 && < 0.4,
         test-framework-quickcheck2 >= 0.2.8 && < 0.4
 

--- a/C-structs.cabal
+++ b/C-structs.cabal
@@ -29,9 +29,15 @@ Library
         Foreign.C.Structs
     Other-Modules:
         Foreign.C.Structs.Types,
+        Foreign.C.Structs.Templates,
         Foreign.C.Structs.Utils
+    Other-Extensions:
+        TemplateHaskell
+    GHC-Options: -ddump-splices
     Default-Language: Haskell2010
-    Build-Depends:  base >= 3.0.0 && < 5.0.0
+    Build-Depends:
+        base >= 3.0.0 && < 5.0.0,
+        template-haskell >= 2.2 && < 2.16
     HS-Source-Dirs: src
 
 Test-Suite unit-tests

--- a/C-structs.cabal
+++ b/C-structs.cabal
@@ -33,7 +33,7 @@ Library
         Foreign.C.Structs.Utils
     Other-Extensions:
         TemplateHaskell
-    GHC-Options: -ddump-splices
+    GHC-Options: -dth-dec-file
     Default-Language: Haskell2010
     Build-Depends:
         base >= 3.0.0 && < 5.0.0,

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ can be interpreted as an equivalent to:
 
 ~~~C
 struct Struct2 {
-    int s2fst;
-    int s2snd;
+    int s21st;
+    int s22nd;
 };
 
 struct Struct2 s;
-s.s2fst = 1;
-s.s2snd = 2;
+s.s21st = 1;
+s.s22nd = 2;
 ~~~
 
 or with Python's ```ctypes```:
@@ -38,7 +38,7 @@ or with Python's ```ctypes```:
 ~~~python
 >>> from ctypes import Structure, c_int
 >>> class Struct2( Structure ):
-...     _fields_ = [("s2fst", c_int), ("s2snd", c_int)]
+...     _fields_ = [("s21st", c_int), ("s22nd", c_int)]
 ...
 >>> s = Struct2(1,2)
 ~~~
@@ -54,8 +54,8 @@ The following shows an example of a foreign import of a ```struct Struct2``` as 
 struct Struct2 *foo (void) {
     struct Struct2 *val;
     val = malloc (sizeof (struct Struct2));
-    val->s2fst = 42;
-    val->s2snd = 63;
+    val->s21st = 42;
+    val->s22nd = 63;
     return val;
 }
 ~~~
@@ -84,6 +84,29 @@ main = do
 For a more elaborated usage examples checkout [```Pythas```](https://github.com/pinselimo/Pythas) in conjunction with [```Pythas-Types```](https://github.com/pinselimo/Pythas-Types).
 It uses ```Foreign.C.Structs``` to declare its storage functions for ```Haskell``` tuples. In addition, its Array and Linked List instances are based on this library.
 
+### More fields
+
+Currently ```C-structs``` exports types featuring up to six fields. If you require more, you can easily create them using Template Haskell and the ```structT``` function:
+
+~~~haskell
+structT 8
+~~~
+
+will create:
+
+~~~haskell
+data Struct8 = Struct8
+    { s81st :: a
+    , s82nd :: b
+    , s83rd :: c
+    , s84th :: d
+    , s85th :: e
+    ...
+    } deriving (Show, Eq)
+
+instance Storable Struct8 ...
+~~~
+
 ## Testing
 
 Identity properties are tested with QuickCheck to ensure that peek and poke are reversible.
@@ -92,10 +115,6 @@ The ```alignment``` function is trivial and only tested implicitly through ```si
 
 Imports from C are tested in ```CTest.hs``` and together with the identity tests form the guarantee that also exports to C are consistent.
 All tests are performed for all available GHC versions through [haskell-ci](https://github.com/haskell-CI/haskell-ci) to ensure maximum compatibility.
-
-## Contributing
-
-Currently only structs with up to four fields are supported. If your use case demands more, feel free to contribute or raise an issue on GitHub. Due to the individuality of the ```sizeOf``` function, an implementation in Template Haskell currently doesn't seem feasible. Thus, instances have to be written one by one.
 
 ## License
 

--- a/src/Foreign/C/Structs.hs
+++ b/src/Foreign/C/Structs.hs
@@ -20,7 +20,7 @@ module Foreign.C.Structs (
     , Struct4(..)
     , Struct5(..)
     , Struct6(..)
-    , StructT
+    , structT
     -- Exports for Template Haskell usage
     , next, sizeof, fmax
     -- Reexports for Template Haskell
@@ -31,10 +31,12 @@ import Foreign.C.Structs.Types (
      Struct2(..)
     ,Struct3(..)
     ,Struct4(..)
+    ,Struct5(..)
+    ,Struct6(..)
     )
 
-import Foreign.C.Structs.Template (
-     StructT
+import Foreign.C.Structs.Templates (
+     structT
     )
 
 import Foreign.Storable (

--- a/src/Foreign/C/Structs.hs
+++ b/src/Foreign/C/Structs.hs
@@ -15,14 +15,37 @@ The types are named after the number of records they support: 'Struct2', 'Struct
 If you'd like to request a type with more records, feel free to issue a PR or contact the maintainer.
 -}
 module Foreign.C.Structs (
-      Struct2( Struct2, s2fst, s2snd)
-    , Struct3( Struct3, s3fst, s3snd, s3trd)
-    , Struct4( Struct4, s4fst, s4snd, s4trd, s4fth)
+      Struct2(..)
+    , Struct3(..)
+    , Struct4(..)
+    , Struct5(..)
+    , Struct6(..)
+    , StructT
+    -- Exports for Template Haskell usage
+    , next, sizeof, fmax
+    -- Reexports for Template Haskell
+    , Storable, peek, poke, sizeOf, alignment, castPtr
     ) where
 
 import Foreign.C.Structs.Types (
      Struct2(..)
     ,Struct3(..)
     ,Struct4(..)
+    )
+
+import Foreign.C.Structs.Template (
+     StructT
+    )
+
+import Foreign.Storable (
+     Storable, peek, poke, sizeOf, alignment
+    )
+import Foreign.Ptr (
+     castPtr
+    )
+import Foreign.C.Structs.Utils (
+     next
+    ,sizeof
+    ,fmax
     )
 

--- a/src/Foreign/C/Structs.hs
+++ b/src/Foreign/C/Structs.hs
@@ -15,6 +15,7 @@ module Foreign.C.Structs (
     , Struct5(..)
     , Struct6(..)
     , structT
+    , acs
     -- Exports for Template Haskell usage
     , next, sizeof, fmax
     -- Reexports for Template Haskell
@@ -30,6 +31,7 @@ import Foreign.C.Structs.Types (
 
 import Foreign.C.Structs.Templates (
      structT
+    ,acs
     )
 
 import Foreign.Storable (

--- a/src/Foreign/C/Structs.hs
+++ b/src/Foreign/C/Structs.hs
@@ -7,12 +7,6 @@ Maintainer      : s.plakolb@gmail.com
 Stability       : beta
 
 The @Foreign.C.Structs@ module allows you to construct C structs of arbitrary @Storable@ types.
-It also defined them as instances of the Storable type-class. You can thus create pointers
-to an instance of such a struct and interface with another language.
-
-Currently up to four records are supported. Each number of records needs its own type.
-The types are named after the number of records they support: 'Struct2', 'Struct3', 'Struct4'.
-If you'd like to request a type with more records, feel free to issue a PR or contact the maintainer.
 -}
 module Foreign.C.Structs (
       Struct2(..)
@@ -26,7 +20,6 @@ module Foreign.C.Structs (
     -- Reexports for Template Haskell
     , Storable, peek, poke, sizeOf, alignment, castPtr
     ) where
-
 import Foreign.C.Structs.Types (
      Struct2(..)
     ,Struct3(..)
@@ -50,4 +43,25 @@ import Foreign.C.Structs.Utils (
     ,sizeof
     ,fmax
     )
+
+{- |
+C-Structs
+---------
+
+The @Foreign.C.Structs@ module allows you to construct C structs of arbitrary @Storable@ types.
+It also defined them as instances of the Storable type-class. You can thus create pointers
+to an instance of such a struct and interface with another language.
+
+Currently up to six records are supported. Each number of records needs its own type.
+The types are named after the number of records they support: 'Struct2', 'Struct3' .. @StructN@
+
+If a Struct type with more fields is required, it can be created using Template Haskell and the 'structT' function:
+
+> structT 8 -- creates a Struct with 8 fields
+
+Field access is provided threefold:
+ * Record syntax
+ * Pattern matching
+ * Template Haskell 'acs' function.
+-}
 

--- a/src/Foreign/C/Structs/Templates.hs
+++ b/src/Foreign/C/Structs/Templates.hs
@@ -4,7 +4,6 @@ module Foreign.C.Structs.Templates
 where
 
 import Language.Haskell.TH
-import Data.List (zipWith4)
 
 import Foreign.Storable (Storable, peek, poke, sizeOf, alignment)
 import Foreign.Ptr (castPtr)
@@ -13,20 +12,31 @@ import Foreign.C.Structs.Utils (next, sizeof, fmax)
 structT :: Int -> DecsQ
 structT = return . zipWith ($) [structTypeT, storableInstanceT] . repeat
 
-sTypeN n = mkName ("Struct" ++ show n)
-struct   = mkName "struct"
-ptr      = mkName "ptr"
+-- Templating functions
 
-fieldnames :: String -> [Name]
-fieldnames s = map (mkName . (:s)) ['a'..'z']
-getters    :: Int -> [Name]
-getters n = map (mkName . (("s" ++ show n) ++))
-          $  ["fst","snd","trd","fth","fif","sxt","sth","egt","nth"]
-          ++ [show n ++ "th" | n <- [10..]]
+structTypeT :: Int -> Dec
+structTypeT nfields = DataD [] (sTypeN nfields) tyVars Nothing [constructor] [deriv]
+    where tyVars    = map PlainTV $ take nfields $ fieldnames ""
+          constructor = RecC (sTypeN nfields) $ take nfields $ records
+          records     = zipWith defRec (getters nfields) (fieldnames "")
+          defRec n t  = (,,) n (Bang NoSourceUnpackedness NoSourceStrictness) (VarT t)
+          deriv = DerivClause Nothing [ConT ''Show, ConT ''Eq]
 
-vals f n s = take n $ zipWith val (fieldnames s) (getters n)
-    where val v getter = ValD (VarP v) (NormalB $ body getter) []
-          body getter  = AppE (VarE f) $ AppE (VarE getter) $ VarE struct
+storableInstanceT :: Int -> Dec
+storableInstanceT nfields = InstanceD Nothing cxt tp decs
+    where vars = take nfields $ fieldnames ""
+          storable = AppT $ ConT ''Storable
+
+          cxt  = map (storable . VarT) vars
+          tp   = storable $ foldl AppT (ConT $ sTypeN nfields) $ map VarT vars
+
+          decs = [ sizeOfT nfields
+                 , alignmentT nfields
+                 , peekT nfields
+                 , pokeT nfields
+                 ]
+
+-- Storable instance function temaples
 
 sizeOfT :: Int -> Dec
 sizeOfT nfields = FunD 'sizeOf [clause]
@@ -50,15 +60,13 @@ peekT nfields = FunD 'peek [clause]
           clause = Clause [VarP ptr] (NormalB body) []
 
           body = DoE $ initial ++ concat gotos ++ final
-          initial = [ BindS (VarP $ head vars) (AppE (VarE 'peek) (AppE (VarE 'Foreign.Ptr.castPtr) (VarE ptr)))
+          initial = [ BindS (VarP $ head vars) (AppE (VarE 'peek) cast_ptr)
                     , BindS (VarP $ head ptrs) (AppE (AppE (VarE 'next) $ VarE ptr) $ VarE $ head vars)
                   ]
           gotos = zipWith3 goto (tail vars) (ptrs) (tail ptrs)
-          goto n p next_p = [bind_var, bind_ptr]
-                where bind_var = BindS (VarP n) (AppE (VarE 'peek) $ VarE p)
-                      bind_ptr = BindS (VarP next_p) (AppE (AppE (VarE 'next) $ VarE p) $ VarE n)
+          goto n p next_p = [bind_var p n, bind_ptr next_p p (VarE n)]
 
-          final = [ BindS (VarP $ last vars) (AppE (VarE 'peek) $ VarE $ last ptrs)
+          final = [ bind_var (last ptrs) (last vars)
                   , NoBindS $ AppE (VarE 'return) $ foldl AppE (ConE (sTypeN nfields)) (map VarE vars)
                 ]
 
@@ -71,35 +79,40 @@ pokeT nfields = FunD 'poke [clause]
 
           patterns = [VarP ptr, ConP (sTypeN nfields) (map VarP vars)]
           body = DoE $ [init_poke, init_next] ++ concat gotos ++ [final]
-          init_poke = NoBindS $ AppE (AppE (VarE 'poke) $ AppE (VarE 'Foreign.Ptr.castPtr) $ VarE ptr) $ VarE $ head vars
-          init_next = BindS (VarP $ head ptrs) (AppE (AppE (VarE 'next) $ VarE ptr) $ VarE $ head vars)
-          final = NoBindS $ AppE (AppE (VarE 'poke) $ VarE $ last ptrs) $ VarE $ last vars
+
+          init_poke = NoBindS
+                    $ AppE cast_poke_ptr (VarE $ head vars)
+                    where  cast_poke_ptr = AppE (VarE 'poke) cast_ptr
+          init_next = bind_ptr (head ptrs) ptr (VarE $ head vars)
 
           gotos = zipWith3 goto (tail vars) (ptrs) $ tail ptrs
-          goto n p next_p = [poke_var, bind_ptr]
+          goto n p next_p = [poke_var p var, bind_ptr next_p p var]
                 where var = VarE n
-                      poke_var = NoBindS $ AppE (AppE (VarE 'poke) $ VarE p) var
-                      bind_ptr = BindS (VarP next_p) $ AppE (AppE (VarE 'next) $ VarE p) var
 
-structTypeT :: Int -> Dec
-structTypeT nfields = DataD [] (sTypeN nfields) tyVars Nothing [constructor] [deriv]
-    where tyVars    = map PlainTV $ take nfields $ fieldnames ""
-          constructor = RecC (sTypeN nfields) $ take nfields $ records
-          records     = zipWith defRec (getters nfields) (fieldnames "")
-          defRec n t  = (,,) n (Bang NoSourceUnpackedness NoSourceStrictness) (VarT t)
-          deriv = DerivClause Nothing [ConT ''Show, ConT ''Eq]
+          final = poke_var (last ptrs) (VarE $ last vars)
 
-storableInstanceT :: Int -> Dec
-storableInstanceT nfields = InstanceD Nothing cxt tp decs
-    where vars = take nfields $ fieldnames ""
-          storable = AppT $ ConT ''Storable
+-- Helpers and Constants
 
-          cxt  = map (storable . VarT) vars
-          tp   = storable $ foldl AppT (ConT $ sTypeN nfields) $ map VarT vars
+sTypeN n = mkName ("Struct" ++ show n)
+struct   = mkName "struct"
+ptr      = mkName "ptr"
+cast_ptr = AppE (VarE 'castPtr) (VarE ptr)
 
-          decs = [ sizeOfT nfields
-                 , alignmentT nfields
-                 , peekT nfields
-                 , pokeT nfields
-                 ]
+fieldnames :: String -> [Name]
+fieldnames s = map (mkName . (:s)) ['a'..'z']
+getters    :: Int -> [Name]
+getters n = map (mkName . (("s" ++ show n) ++))
+          $  ["fst","snd","trd","fth","fif","sxt","sth","egt","nth"]
+          ++ [show n ++ "th" | n <- [10..]]
+
+vals f n s = take n $ zipWith val (fieldnames s) (getters n)
+    where val v getter = ValD (VarP v) (NormalB $ body getter) []
+          body getter  = AppE (VarE f) $ AppE (VarE getter) $ VarE struct
+
+bind_var ptr var = BindS (VarP var) (AppE (VarE 'peek) $ VarE ptr)
+poke_var ptr var = NoBindS
+       $ AppE (AppE (VarE 'poke) $ VarE ptr) var
+bind_ptr np pp var = BindS (VarP np)
+       $ AppE next_ptr var
+       where next_ptr = AppE (VarE 'next) $ VarE pp
 

--- a/src/Foreign/C/Structs/Templates.hs
+++ b/src/Foreign/C/Structs/Templates.hs
@@ -102,8 +102,8 @@ fieldnames :: String -> [Name]
 fieldnames s = map (mkName . (:s)) ['a'..'z']
 getters    :: Int -> [Name]
 getters n = map (mkName . (("s" ++ show n) ++))
-          $  ["fst","snd","trd","fth","fif","sxt","sth","egt","nth"]
-          ++ [show n ++ "th" | n <- [10..]]
+          $  ["1st","2nd","3rd"]
+          ++ [show n ++ "th" | n <- [4..]]
 
 vals f n s = take n $ zipWith val (fieldnames s) (getters n)
     where val v getter = ValD (VarP v) (NormalB $ body getter) []

--- a/src/Foreign/C/Structs/Templates.hs
+++ b/src/Foreign/C/Structs/Templates.hs
@@ -46,7 +46,9 @@ structTypeT nfields = DataD [] (sTypeN nfields) tyVars Nothing [constructor] [de
 #endif
           deriv'' = [''Show, ''Eq]
           deriv' = map ConT deriv''
+#if __GLASGOW_HASKELL__ > 800
           deriv = DerivClause Nothing deriv'
+#endif
 
 storableInstanceT :: Int -> Dec
 storableInstanceT nfields = InstanceD Nothing cxt tp decs

--- a/src/Foreign/C/Structs/Templates.hs
+++ b/src/Foreign/C/Structs/Templates.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Foreign.C.Structs.Templates
+    (structT)
+where
+
+import Language.Haskell.TH
+import Data.List (zipWith4)
+
+import Foreign.Storable (Storable, peek, poke, sizeOf, alignment)
+import Foreign.Ptr (castPtr)
+import Foreign.C.Structs.Utils (next, sizeof, fmax)
+
+structT :: Int -> DecsQ
+structT = return . zipWith ($) [structTypeT, storableInstanceT] . repeat
+
+sTypeN n = mkName ("Struct" ++ show n)
+struct  = mkName "struct"
+
+fieldnames :: String -> [Name]
+fieldnames s = map (mkName . (:s)) ['a'..'z']
+getters :: Int -> [Name]
+getters n = map (mkName . (("s" ++ show n) ++)) $
+            ["fst","snd","trd","fth","fif","sxt","sth","egt","nth"] ++ [show n ++ "th" | n <- [10..]]
+
+vals f n s = take n $ zipWith val (fieldnames s) (getters n)
+    where val v getter = ValD (VarP v) (NormalB $ body getter) []
+          body getter  = AppE (VarE f) $ AppE (VarE getter) $ VarE struct
+
+sizeOfT :: Int -> Dec
+sizeOfT nfields = FunD 'sizeOf [clause]
+    where clause = Clause [VarP struct] (NormalB body) wheres
+          body = AppE (AppE (VarE 'sizeof) $ alignments "a") (sizes "s")
+          alignments = ListE . take nfields . map VarE . fieldnames
+          sizes = ListE . take nfields . map VarE . fieldnames
+          wheres = vals 'alignment nfields "a" ++ vals 'sizeOf nfields "s"
+
+alignmentT :: Int -> Dec
+alignmentT nfields = FunD 'alignment [clause]
+     where clause = Clause [VarP struct] (NormalB body) wheres
+           body = AppE (VarE 'fmax) (ListE $ take nfields $ map VarE $ fieldnames "")
+           wheres = vals 'alignment nfields ""
+
+peekT :: Int -> Dec
+peekT nfields = FunD 'peek [clause]
+    where
+          ptr = mkName "ptr"
+          vars = take nfields $ fieldnames ""
+          ptrs = tail $ take nfields $ fieldnames "_ptr"
+
+          clause = Clause [VarP ptr] (NormalB body) []
+
+          body = DoE $ initial ++ concat gotos ++ final
+          initial = [ BindS (VarP $ head vars) (AppE (VarE 'peek) (AppE (VarE 'castPtr) (VarE ptr)))
+                    , BindS (VarP $ head ptrs) (AppE (AppE (VarE 'next) $ VarE ptr) $ VarE $ head vars)
+                  ]
+          gotos = zipWith4 goto (tail vars) (ptrs) vars (tail ptrs)
+          goto n p prev next_p = [bind_var, bind_ptr]
+                where bind_var = BindS (VarP n) (AppE (VarE 'peek) $ VarE p)
+                      bind_ptr = BindS (VarP next_p) (AppE (AppE (VarE 'next) $ VarE p) $ VarE prev)
+
+          final = [ BindS (VarP $ last vars) (AppE (VarE 'peek) $ VarE $ last ptrs)
+                  , NoBindS $ AppE (VarE 'return) $ foldl AppE (ConE (sTypeN nfields)) (map VarE vars)
+                ]
+
+pokeT :: Int -> Dec
+pokeT nfields = FunD 'poke [clause]
+    where
+          ptr = mkName "ptr"
+          vars = take nfields $ fieldnames ""
+          ptrs = tail $ take nfields $ fieldnames "_ptr"
+
+          clause = Clause patterns (NormalB body) []
+
+          patterns = [VarP ptr, ConP (sTypeN nfields) (map VarP vars)]
+          body = DoE $ [init_poke, init_next] ++ concat gotos ++ [final]
+          init_poke = NoBindS $ AppE (AppE (VarE 'poke) $ AppE (VarE 'castPtr) $ VarE ptr) $ VarE $ head vars
+          init_next = BindS (VarP $ head ptrs) (AppE (AppE (VarE 'next) $ VarE ptr) $ VarE $ head vars)
+          gotos = init gotos'
+          final = head $ last gotos'
+
+          gotos' = zipWith4 goto (tail vars) (ptrs) vars $ tail ptrs ++ [ptr]
+          goto n p prev next_p = [poke_var, bind_ptr]
+                where poke_var = NoBindS $ AppE (AppE (VarE 'poke) $ VarE p) $ VarE $ n
+                      bind_ptr = BindS (VarP next_p) $ AppE (AppE (VarE 'next) $ VarE p) $ VarE prev
+
+structTypeT :: Int -> Dec
+structTypeT nfields = DataD [] (sTypeN nfields) tyVars Nothing [constructor] [deriv]
+    where tyVars    = map PlainTV $ take nfields $ fieldnames ""
+          constructor = RecC (sTypeN nfields) $ take nfields $ records
+          records     = zipWith defRec (getters nfields) (fieldnames "")
+          defRec n t  = (,,) n (Bang NoSourceUnpackedness NoSourceStrictness) (VarT t)
+          deriv = DerivClause Nothing [ConT ''Show, ConT ''Eq]
+
+storableInstanceT :: Int -> Dec
+storableInstanceT nfields = InstanceD Nothing cxt tp decs
+    where vars = take nfields $ fieldnames ""
+          storable = AppT $ ConT ''Storable
+
+          cxt  = map (storable . VarT) vars
+          tp   = storable $ foldl AppT (ConT $ sTypeN nfields) $ map VarT vars
+
+          decs = [ sizeOfT nfields
+                 , alignmentT nfields
+                 , peekT nfields
+                 , pokeT nfields
+                 ]
+

--- a/src/Foreign/C/Structs/Templates.hs
+++ b/src/Foreign/C/Structs/Templates.hs
@@ -58,8 +58,11 @@ storableInstanceT nfields = InstanceD Nothing cxt tp decs
 #endif
     where vars = take nfields $ fieldnames ""
           storable = AppT $ ConT ''Storable
-
+#if __GLASGOW_HASKELL__ < 710
+          cxt  = map (\v -> ClassP ''Storable [VarT v]) vars
+#else
           cxt  = map (storable . VarT) vars
+#endif
           tp   = storable $ foldl AppT (ConT $ sTypeN nfields) $ map VarT vars
 
           decs = [ sizeOfT nfields

--- a/src/Foreign/C/Structs/Templates.hs
+++ b/src/Foreign/C/Structs/Templates.hs
@@ -9,6 +9,10 @@ import Foreign.Storable (Storable, peek, poke, sizeOf, alignment)
 import Foreign.Ptr (castPtr)
 import Foreign.C.Structs.Utils (next, sizeof, fmax)
 
+-- | All @StructN@ types and their instances of 'Storable' are declared using 'structT'.
+-- It can theoretically create C structs with an infinite number of fields.
+-- The parameter of 'structT' is the number of fields the struct type should have.
+-- Its constructor and type will both be named @StructN@ where N is equal to the argument to 'structT'.
 structT :: Int -> DecsQ
 structT = return . zipWith ($) [structTypeT, storableInstanceT] . repeat
 

--- a/src/Foreign/C/Structs/Templates.hs
+++ b/src/Foreign/C/Structs/Templates.hs
@@ -1,4 +1,14 @@
 {-# LANGUAGE TemplateHaskell #-}
+{- |
+Module          : Foreign.C.Structs.Templates
+Description     : Create C structs from Haskell
+Copyright       : (c) Simon Plakolb, 2020
+License         : MIT
+Maintainer      : s.plakolb@gmail.com
+Stability       : beta
+
+This module exposes the template haskell framework to create Struct types.
+-}
 module Foreign.C.Structs.Templates
     (structT)
 where

--- a/src/Foreign/C/Structs/Templates.hs
+++ b/src/Foreign/C/Structs/Templates.hs
@@ -30,7 +30,7 @@ structT = return . zipWith ($) [structTypeT, storableInstanceT] . repeat
 
 structTypeT :: Int -> Dec
 #if __GLASGOW_HASKELL__ < 800
-structTypeT nfields = DataD [] (sTypeN nfields) tyVars Nothing [constructor] deriv''
+structTypeT nfields = DataD [] (sTypeN nfields) tyVars [constructor] deriv''
 #elif __GLASGOW_HASKELL__ < 802
 structTypeT nfields = DataD [] (sTypeN nfields) tyVars Nothing [constructor] deriv'
 #else
@@ -51,7 +51,11 @@ structTypeT nfields = DataD [] (sTypeN nfields) tyVars Nothing [constructor] [de
 #endif
 
 storableInstanceT :: Int -> Dec
+#if __GLASGOW_HASKELL__ < 800
+storableInstanceT nfields = InstanceD cxt tp decs
+#else
 storableInstanceT nfields = InstanceD Nothing cxt tp decs
+#endif
     where vars = take nfields $ fieldnames ""
           storable = AppT $ ConT ''Storable
 

--- a/src/Foreign/C/Structs/Templates.hs
+++ b/src/Foreign/C/Structs/Templates.hs
@@ -14,7 +14,6 @@ module Foreign.C.Structs.Templates
 where
 
 import Language.Haskell.TH
-import Language.Haskell.TH.Lib (DerivClause)
 
 import Foreign.Storable (Storable, peek, poke, sizeOf, alignment)
 import Foreign.Ptr (castPtr)

--- a/src/Foreign/C/Structs/Types.hs
+++ b/src/Foreign/C/Structs/Types.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Foreign.C.Structs.Types (
-    Struct2(..), Struct3(..), Struct4(..)
+    Struct2(..), Struct3(..), Struct4(..), Struct5(..), Struct6(..)
 ) where
 
 import Foreign.Storable (Storable, peek, poke, alignment, sizeOf)

--- a/src/Foreign/C/Structs/Types.hs
+++ b/src/Foreign/C/Structs/Types.hs
@@ -12,4 +12,6 @@ import Foreign.C.Structs.Templates (structT)
 structT 2
 structT 3
 structT 4
+structT 5
+structT 6
 

--- a/src/Foreign/C/Structs/Types.hs
+++ b/src/Foreign/C/Structs/Types.hs
@@ -1,4 +1,14 @@
 {-# LANGUAGE TemplateHaskell #-}
+{- |
+Module          : Foreign.C.Structs.Types
+Description     : Create C structs from Haskell
+Copyright       : (c) Simon Plakolb, 2020
+License         : MIT
+Maintainer      : s.plakolb@gmail.com
+Stability       : beta
+
+This module creates tuples with up to 6 fields.
+-}
 module Foreign.C.Structs.Types (
     Struct2(..), Struct3(..), Struct4(..), Struct5(..), Struct6(..)
 ) where
@@ -9,9 +19,29 @@ import Foreign.Ptr (Ptr, castPtr)
 import Foreign.C.Structs.Utils
 import Foreign.C.Structs.Templates (structT)
 
+-- | A 'Struct2' can hold two records of any 'Storable' types @a@ and @b@.
+-- It is itself an instance of 'Storable' and can be used inside a 'Ptr'.
+-- The 'Struct2' constructor takes two arguments.
+-- The record functions 's21st' and 's22nd' provide access to the fields values.
 structT 2
+-- | A 'Struct3' can hold three records of any 'Storable' types @a@, @b@ and @c@.
+-- It is itself an instance of 'Storable' and can be used inside a 'Ptr'.
+-- The 'Struct3' constructor takes three arguments.
+-- The record functions 's31st', 's32nd' and 's33rd' provide access to the fields values.
 structT 3
+-- | A 'Struct4' can hold four records of any 'Storable' types @a@, @b@, @c@ and @d@.
+-- It is itself an instance of 'Storable' and can be used inside a 'Ptr'.
+-- The 'Struct4' constructor takes four arguments.
+-- The record functions 's41st', 's42nd', 's43rd' and 's44th' provide access to the fields values.
 structT 4
+-- | A 'Struct5' can hold five records of any 'Storable' types @a@, @b@, @c@, @d@ and @e@.
+-- It is itself an instance of 'Storable' and can be used inside a 'Ptr'.
+-- The 'Struct5' constructor takes five arguments.
+-- The record functions 's51st', 's52nd', 's53rd', 's54th' and 's55th' provide access to the fields values.
 structT 5
+-- | A 'Struct6' can hold six records of any 'Storable' types @a@, @b@, @c@, @d@, @e@ and @f@.
+-- It is itself an instance of 'Storable' and can be used inside a 'Ptr'.
+-- The 'Struct6' constructor takes six arguments.
+-- The record functions 's61st', 's62nd', 's63rd', 's64th', 's65th' and 's66th' provide access to the fields values.
 structT 6
 

--- a/src/Foreign/C/Structs/Types.hs
+++ b/src/Foreign/C/Structs/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 module Foreign.C.Structs.Types (
     Struct2(..), Struct3(..), Struct4(..)
 ) where
@@ -6,129 +7,9 @@ import Foreign.Storable (Storable, peek, poke, alignment, sizeOf)
 import Foreign.Ptr (Ptr, castPtr)
 
 import Foreign.C.Structs.Utils
+import Foreign.C.Structs.Templates (structT)
 
--- | A 'Struct2' can hold two records of any 'Storable' types @a@ and @b@.
--- It is itself an instance.
--- The Constructor 'Struct2' for structs with two fields takes two arguments. Both must be instances of 'Storable' and can be used inside a 'Ptr'.
-data Struct2 a b = Struct2 {
-      -- | Accesses the first field of a 'Struct2'
-      s2fst :: a
-      -- | Accesses the second field of a 'Struct2'
-    , s2snd :: b
-    } deriving (Show, Eq)
-
-s2Size :: (Storable a, Storable b) => Struct2 a b -> Int
-s2Size = (2*) . s2Alignment
-
-s2Alignment :: (Storable a, Storable b) => Struct2 a b -> Int
-s2Alignment cs = fmax [alignment $ s2fst cs, alignment $ s2snd cs]
-
-instance (Storable a, Storable b) => Storable (Struct2 a b) where
-    sizeOf    = s2Size
-    alignment = s2Alignment
-    peek ptr  = do
-        a <- peek (castPtr ptr)
-        b <- peek =<< next ptr a
-        return $ Struct2 a b
-    poke ptr (Struct2 a b) = do
-        poke (castPtr ptr) a
-        ptr_b <- next ptr a
-        poke ptr_b b
-
--- | A 'Struct3' can hold three records of any 'Storable' types @a@, @b@ and @c@.
--- It is itself an instance.
--- The constructor 'Struct3' for structs with three fields takes three arguments. All of which must be instances of 'Storable' and can be used inside a 'Ptr'.
-data Struct3 a b c = Struct3 {
-      -- | Accesses the first field of a 'Struct3'
-      s3fst :: a
-      -- | Accesses the second field of a 'Struct3'
-    , s3snd :: b
-      -- | Accesses the third field of a 'Struct3'
-    , s3trd :: c
-    } deriving (Show, Eq)
-
-s3Size :: (Storable a, Storable b, Storable c) => Struct3 a b c -> Int
-s3Size cs = sizeof [aa,ab,ac] [sa, sb, sc]
-    where sa = sizeOf $ s3fst cs
-          sb = sizeOf $ s3snd cs
-          sc = sizeOf $ s3trd cs
-          aa = alignment $ s3fst cs
-          ab = alignment $ s3snd cs
-          ac = alignment $ s3trd cs
-
-s3Alignment :: (Storable a, Storable b, Storable c) => Struct3 a b c -> Int
-s3Alignment cs = fmax [a,b,c]
-    where a = alignment $ s3fst cs
-          b = alignment $ s3snd cs
-          c = alignment $ s3trd cs
-
-instance (Storable a, Storable b, Storable c) => Storable (Struct3 a b c) where
-    sizeOf    = s3Size
-    alignment = s3Alignment
-    peek ptr  = do
-        a <- peek (castPtr ptr)
-        ptr_b <- next ptr a
-        b <- peek ptr_b
-        ptr_c <- next ptr_b b
-        c <- peek ptr_c
-        return $ Struct3 a b c
-    poke ptr (Struct3 a b c) = do
-        poke (castPtr ptr) a
-        ptr_b <- next ptr a
-        poke ptr_b b
-        ptr_c <- next ptr_b b
-        poke ptr_c c
-
--- | A 'Struct4' can hold four records of any 'Storable' types @a@, @b@, @c@ and @d@.
--- It is itself an instance of 'Storable' and can be used inside a 'Ptr'.
--- The 'Struct4' constructor takes four arguments. All must be instances of 'Storable'.
-data Struct4 a b c d = Struct4 {
-    -- | Accesses the first field of a 'Struct4'
-      s4fst :: a
-    -- | Accesses the second field of a 'Struct4'
-    , s4snd :: b
-    -- | Accesses the third field of a 'Struct4'
-    , s4trd :: c
-    -- | Accesses the fourth field of a 'Struct4'
-    , s4fth :: d
-    } deriving (Show, Eq)
-
-s4Size :: (Storable a, Storable b, Storable c, Storable d) => Struct4 a b c d -> Int
-s4Size cs = sizeof [aa,ab,ac,ad] [sa,sb,sc,sd]
-    where sa = sizeOf $ s4fst cs
-          sb = sizeOf $ s4snd cs
-          sc = sizeOf $ s4trd cs
-          sd = sizeOf $ s4fth cs
-          aa = alignment $ s4fst cs
-          ab = alignment $ s4snd cs
-          ac = alignment $ s4trd cs
-          ad = alignment $ s4fth cs
-
-s4Alignment :: (Storable a, Storable b, Storable c, Storable d) => Struct4 a b c d -> Int
-s4Alignment cs = fmax [a, b, c, d]
-    where a = alignment $ s4fst cs
-          b = alignment $ s4snd cs
-          c = alignment $ s4trd cs
-          d = alignment $ s4fth cs
-
-instance (Storable a, Storable b, Storable c, Storable d) => Storable (Struct4 a b c d) where
-    sizeOf    = s4Size
-    alignment = s4Alignment
-    peek ptr  = do
-        a <- peek (castPtr ptr)
-        ptr_b <- next ptr a
-        b <- peek ptr_b
-        ptr_c <- next ptr_b b
-        c <- peek ptr_c
-        ptr_d <- next ptr_c c
-        d <- peek ptr_d
-        return $ Struct4 a b c d
-    poke ptr (Struct4 a b c d) = do
-        poke (castPtr ptr) a
-        ptr_b <- next ptr a
-        poke ptr_b b
-        ptr_c <- next ptr_b b
-        poke ptr_c c
-        ptr_d <- next ptr_c c
-        poke ptr_d d
+structT 2
+structT 3
+structT 4
 

--- a/src/Foreign/C/Structs/Utils.hs
+++ b/src/Foreign/C/Structs/Utils.hs
@@ -1,3 +1,13 @@
+{- |
+Module          : Foreign.C.Structs.Utils
+Description     : Create C structs from Haskell
+Copyright       : (c) Simon Plakolb, 2020
+License         : MIT
+Maintainer      : s.plakolb@gmail.com
+Stability       : beta
+
+This module defined some utility functions for Storable instance declarations.
+-}
 module Foreign.C.Structs.Utils (
       next, fmax, sizeof
 ) where
@@ -6,6 +16,7 @@ import Foreign.Storable (Storable, peek, sizeOf, alignment)
 import Foreign.Marshal (alloca)
 import Foreign.Ptr (Ptr, plusPtr, alignPtr)
 
+-- | Due to alignment constraints the size of C structs is dependent on the order of fields and their respectible sizes. The function 'sizeof' can calculate the resulting size given a list of all 'alignments' and 'sizes'.
 sizeof :: [Int] -> [Int] -> Int
 sizeof alignments sizes = sizeof' 0 alignments sizes
     where
@@ -19,6 +30,7 @@ pad x a
   | x `mod` a == 0 = x
   | otherwise      = pad (x+1) a
 
+-- | Jumps to the next pointer location in the struct.
 next :: (Storable a, Storable b, Storable c) => Ptr a -> b -> IO (Ptr c)
 next ptr x = alloca $ next' ptr x
     where next' :: (Storable a, Storable b, Storable c) => Ptr a -> b -> Ptr c -> IO (Ptr c)
@@ -27,6 +39,7 @@ next ptr x = alloca $ next' ptr x
                 y <- peek ptr_x
                 return $ alignPtr ptr_y $ alignment y
 
+-- | Alias for @foldr max 0@.
 fmax :: Integral a => [a] -> a
 fmax = foldr max 0
 

--- a/src/Foreign/C/Structs/Utils.hs
+++ b/src/Foreign/C/Structs/Utils.hs
@@ -29,3 +29,4 @@ next ptr x = alloca $ next' ptr x
 
 fmax :: Integral a => [a] -> a
 fmax = foldr max 0
+

--- a/test/CTest.hs
+++ b/test/CTest.hs
@@ -2,7 +2,7 @@
 module CTest where
 
 import Test.Framework.Providers.API (testGroup)
-import CTestTemplate
+import Templates
 
 import Foreign.C.Types
 import Foreign.C.Structs

--- a/test/CTest.hs
+++ b/test/CTest.hs
@@ -1,37 +1,41 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ForeignFunctionInterface, TemplateHaskell #-}
 module CTest where
 
 import Test.Framework.Providers.API (testGroup)
-import Test.Framework.Providers.HUnit (testCase)
-import Test.HUnit ((@?=))
+import CTestTemplate
 
 import Foreign.C.Types
 import Foreign.C.Structs
-import Foreign.Ptr
-import Foreign.Storable
-import Foreign.Marshal.Alloc
 
-peek' ptr = do
-      val <- peek ptr
-      free ptr
-      return val
+i = 63 :: CInt
+d = 63.63 :: CDouble
+f = 42.42 :: CFloat
+ch = 1 :: CChar
 
-foreign import ccall "sIntDouble" sIntDouble :: Ptr (Struct2 CInt CDouble)
-foreign import ccall "sIntInt" sIntInt :: Ptr (Struct2 CInt CInt)
-foreign import ccall "sDoubleFloat" sDoubleFloat :: Ptr (Struct2 CDouble CFloat)
-foreign import ccall "sIntCharDouble" sIntCharDouble :: Ptr (Struct3 CInt CChar CDouble)
-foreign import ccall "sIntDoubleChar" sIntDoubleChar :: Ptr (Struct3 CInt CDouble CChar)
-foreign import ccall "sIntCharDoubleDouble" sIntCharDoubleDouble :: Ptr (Struct4 CInt CChar CDouble CDouble)
-foreign import ccall "sIntDoubleDoubleInt" sIntDoubleDoubleInt :: Ptr (Struct4 CInt CDouble CDouble CInt)
-foreign import ccall "sDoubleIntCharChar" sDoubleIntCharChar :: Ptr (Struct4 CDouble CInt CChar CChar)
+s2id = Struct2 i d
+s2ii = Struct2 i i
+s2df = Struct2 d f
 
-tests = testGroup "Foreign Imports" [
-        testCase "sIntDouble"     $ (peek' sIntDouble)     >>= (@?= Struct2 63 63.63)
-      , testCase "sIntInt"        $ (peek' sIntInt)        >>= (@?= Struct2 63 63)
-      , testCase "sDoubleFloat"   $ (peek' sDoubleFloat)   >>= (@?= Struct2 63.63 42.42)
-      , testCase "sIntCharDouble" $ (peek' sIntCharDouble) >>= (@?= Struct3 63 1 63.63)
-      , testCase "sIntDoubleChar" $ (peek' sIntDoubleChar) >>= (@?= Struct3 63 63.63 1)
-      , testCase "sIntCharDoubleDouble" $ (peek' sIntCharDoubleDouble) >>= (@?= Struct4 63 1 63.63 63.63)
-      , testCase "sIntDoubleDoubleInt"  $ (peek' sIntDoubleDoubleInt)  >>= (@?= Struct4 63 63.63 63.63 63)
-      , testCase "sDoubleIntCharChar"   $ (peek' sDoubleIntCharChar)   >>= (@?= Struct4 63.63 63 1 1)
+s3icd = Struct3 i ch d
+s3idc = Struct3 i d ch
+
+s4icdd = Struct4 i ch d d
+s4iddi = Struct4 i d  d i
+s4dicc = Struct4 d i ch ch
+
+c "sIntDouble"   's2id
+c "sIntInt"      's2ii
+c "sDoubleFloat" 's2df
+
+c "sIntCharDouble" 's3icd
+c "sIntDoubleChar" 's3idc
+
+c "sIntCharDoubleDouble" 's4icdd
+c "sIntDoubleDoubleInt"  's4iddi
+c "sDoubleIntCharChar"   's4dicc
+
+tests = testGroup "ForeignImports" [
+      case_sIntDouble, case_sIntInt, case_sDoubleFloat
+    , case_sIntCharDouble, case_sIntDoubleChar
+    , case_sIntCharDoubleDouble, case_sIntDoubleDoubleInt, case_sDoubleIntCharChar
     ]

--- a/test/CTestTemplate.hs
+++ b/test/CTestTemplate.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TemplateHaskell #-}
+module CTestTemplate where
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Syntax (Lift)
+import Foreign.Ptr (Ptr)
+import Foreign.Marshal.Alloc (free)
+import Foreign.Storable (peek)
+import Test.HUnit ((@?=))
+import Test.Framework.Providers.HUnit (testCase)
+
+peek' ptr = do
+      val <- peek ptr
+      free ptr
+      return val
+
+c :: String -> Name -> DecsQ
+c cname res = do
+    VarI n t d <- reify res
+    typ <- ptr $ return t
+    let name = mkName cname
+        deq  = ForeignD $ ImportF CCall Safe cname name typ
+        body = normalB [| testCase cname $ (peek' $(varE name)) >>= (@?= $(varE n)) |]
+        test = funD (mkName $ "case_" ++ cname) [clause [] body []]
+    sequence [return deq, test]
+
+ptr t = [t| Ptr $(t) |]
+
+to_struct_type :: [TypeQ] -> TypeQ
+to_struct_type ts = [t| Ptr $(mk_struct) |]
+    where struct = conT (mkName $ "Struct" ++ (show $ length ts))
+          mk_struct :: TypeQ
+          mk_struct = foldr appT struct ts
+
+
+cint = conT (mkName "Struct CInt CInt")
+cdouble = conT (mkName "CDouble")
+

--- a/test/CTestTemplate.hs
+++ b/test/CTestTemplate.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell, CPP #-}
 module CTestTemplate where
 
 import Language.Haskell.TH
@@ -16,7 +16,11 @@ peek' ptr = do
 
 c :: String -> Name -> DecsQ
 c cname res = do
-    VarI n t d <- reify res
+#if __GLASGOW_HASKELL__ < 800
+    VarI n t _ _ <- reify res
+#else
+    VarI n t _ <- reify res
+#endif
     typ <- ptr $ return t
     let name = mkName cname
         deq  = ForeignD $ ImportF CCall Safe cname name typ

--- a/test/Templates.hs
+++ b/test/Templates.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE TemplateHaskell, CPP #-}
-module CTestTemplate where
+module Templates where
 
 import Language.Haskell.TH
 import Language.Haskell.TH.Syntax (Lift)
@@ -35,8 +35,4 @@ to_struct_type ts = [t| Ptr $(mk_struct) |]
     where struct = conT (mkName $ "Struct" ++ (show $ length ts))
           mk_struct :: TypeQ
           mk_struct = foldr appT struct ts
-
-
-cint = conT (mkName "Struct CInt CInt")
-cdouble = conT (mkName "CDouble")
 


### PR DESCRIPTION
## Prerequisites

Recently ```sizeof``` has been introduced. It can calculate the size of a struct now independent of its size just by looking at the alignment constraints as well as the sizes of the fields.

## Reward

Now that a generic interface for creating struct instances of ```Storable``` is available, it can be leveraged through Template Haskell. This PR introduced as ```structT``` templating function, that can create ```StructN``` data declarations with ```N``` fields.

With this expansion it is now possible to define structs with 6 fields as a default while leaving structs of arbitrary size open to the user.